### PR TITLE
hotfix: EC2 알림 정책 전반 재조정

### DIFF
--- a/.github/workflows/ec2-anomaly-cost-alert.yml
+++ b/.github/workflows/ec2-anomaly-cost-alert.yml
@@ -313,7 +313,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Send Slack cost notification
-        if: ${{ always() }}
+        if: >-
+          ${{
+            steps.lowutil.outputs.severity == 'warning'
+            || (github.event_name == 'workflow_dispatch' && (github.event.inputs.mode == 'cost' || github.event.inputs.mode == 'all'))
+          }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -328,7 +332,11 @@ jobs:
             --data "${payload}"
 
       - name: Send SNS email cost notification
-        if: ${{ always() }}
+        if: >-
+          ${{
+            steps.lowutil.outputs.severity == 'warning'
+            || (github.event_name == 'workflow_dispatch' && (github.event.inputs.mode == 'cost' || github.event.inputs.mode == 'all'))
+          }}
         env:
           ALERT_SNS_TOPIC_ARN: ${{ secrets.ALERT_SNS_TOPIC_ARN }}
           TITLE: ${{ steps.lowutil.outputs.title }}


### PR DESCRIPTION
## Summary
- EC2 이상 징후 탐지 워크플로우에 5 */8 * * * 스케줄을 추가해 정상 상태 요약 알림을 하루 3회로 제한했습니다.
- 실시간(10분 주기) 실행에서는 이상 감지(severity == danger)일 때만 Slack/SNS 즉시 알림이 전송되도록 조건을 분리했습니다.
- 비용 최적화 알림은 저사용 후보가 감지된 경우(severity == warning)에만 전송되도록 변경해 불필요한 알림을 줄였습니다.
- 수동 실행(workflow_dispatch)은 운영 점검 용도로 알림 전송을 유지했습니다.

## Linked Issue
Closes #23

## Test Plan
- [x] Actions에서 mode=realtime 수동 실행 시 알림이 정상 전송되는지 확인
- [x] severity=good 결과에서 10분 주기 실행은 알림이 미전송되는지 확인
- [x] severity=danger 결과에서 10분 주기 실행은 즉시 알림이 전송되는지 확인
- [x] 5 */8 * * * 스케줄 실행에서 정상 상태 요약 알림이 하루 3회로 제한되는지 확인
- [x] 비용 최적화 실행에서 후보가 없는 경우 알림이 미전송되는지 확인
- [x] 비용 최적화 실행에서 후보가 있는 경우 알림이 전송되는지 확인