### PR TITLE
fix: remove inactive EC2 schedule targets from configuration

### DIFF
--- a/config/ec2_schedule_targets.csv
+++ b/config/ec2_schedule_targets.csv
@@ -1,6 +1,4 @@
 name_tag,owner_name
 mlops-tyler,송민성
-mlops-jslee,이재석
-mlops-jay,유준우
 mlops-lazenca,송용단
 mlops-etf,문성호


### PR DESCRIPTION
- Deleted entries for mlops-jslee and mlops-jay from the EC2 schedule targets CSV to streamline the configuration and reflect current team members.