### PR TITLE
운영 기간 3/15 연장 및 비용-성능 최적화 적용

### DIFF
--- a/.github/workflows/ec2-anomaly-cost-alert.yml
+++ b/.github/workflows/ec2-anomaly-cost-alert.yml
@@ -40,7 +40,7 @@ jobs:
           fi
 
           today_kst="$(TZ=Asia/Seoul date +%Y-%m-%d)"
-          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-11" ]]; then
+          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-15" ]]; then
             echo "in_window=false" >> "$GITHUB_OUTPUT"
           else
             echo "in_window=true" >> "$GITHUB_OUTPUT"
@@ -264,7 +264,7 @@ jobs:
           fi
 
           today_kst="$(TZ=Asia/Seoul date +%Y-%m-%d)"
-          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-11" ]]; then
+          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-15" ]]; then
             echo "in_window=false" >> "$GITHUB_OUTPUT"
           else
             echo "in_window=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ec2-queue-autoscale.yml
+++ b/.github/workflows/ec2-queue-autoscale.yml
@@ -33,7 +33,7 @@ jobs:
           fi
 
           today_kst="$(TZ=Asia/Seoul date +%Y-%m-%d)"
-          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-11" ]]; then
+          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-15" ]]; then
             echo "in_window=false" >> "$GITHUB_OUTPUT"
           else
             echo "in_window=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ec2-scheduled-control.yml
+++ b/.github/workflows/ec2-scheduled-control.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
           today_kst="$(TZ=Asia/Seoul date +%Y-%m-%d)"
-          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-11" ]]; then
+          if [[ "$today_kst" < "2026-02-27" || "$today_kst" > "2026-03-15" ]]; then
             echo "in_window=false" >> "$GITHUB_OUTPUT"
           else
             echo "in_window=true" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - 코드 수정 가능 기간: 2026-02-27 ~ 2026-03-11 (의논 후 결정)
 - 코드 프리즈: 2026-03-12(의논 후 결정)
 - 최종 발표일: 2026-03-13
+- 최대 작동일: 2026-03-15
 - 기술스택: Python, uv, PyTorch, AWS S3, AWS SQS, W&B, GitHub Actions, Slack Bot, Docker, Airflow
 
 ## 2. Team Members
@@ -90,18 +91,23 @@ cp .env.example .env
 - `ec2-scheduled-control.yml`: 평일 매시 실행으로 `config/ec2_schedule_targets.csv`의 role별 시작/중지 시간 정책 자동 적용
 - `ec2-queue-autoscale.yml`: SQS backlog 기반 `role=train|infer` 워커 자동 시작/중지
 - `ec2-anomaly-cost-alert.yml`: 10분 단위 이상 징후(고CPU/디스크 부족 위험/헬스체크 실패) 탐지 + 24시간 평균 CPU/Network/Disk 기준 저사용 후보 알림
-- 스케줄 기반 워크플로우는 `2026-02-27` ~ `2026-03-11` 기간에서만 실행되도록 기간 가드 적용
+- 스케줄 기반 워크플로우는 `2026-02-27` ~ `2026-03-15` 기간에서만 실행되도록 기간 가드 적용
+- 비용 상한(3/15 누적 10만원) 운영을 위해 Repository Variables 기본값:
+  - `TRAIN_QUEUE_SCALE_OUT_THRESHOLD=2`
+  - `INFER_QUEUE_SCALE_OUT_THRESHOLD=5`
+  - `QUEUE_SCALE_IN_IDLE_MINUTES=10`
+  - `QUEUE_IDLE_CPU_THRESHOLD=2`
 
 ## 8. Airflow 오케스트레이션
 
 - DAG 1: `airflow/dags/mlops_train_pipeline.py`
   - `validate_env` -> `dispatch_train_message` -> `quality_gate_candidate`
   - 스케줄: 매일 UTC `02:00` (`0 2 * * *`)
-  - 실행 기간: `2026-02-27` ~ `2026-03-11` (`start_date`/`end_date` 고정)
+  - 실행 기간: `2026-02-27` ~ `2026-03-15` (`start_date`/`end_date` 고정)
 - DAG 2: `airflow/dags/mlops_infer_pipeline.py`
   - `validate_env` -> `dispatch_infer_message`
   - 스케줄: 매일 UTC `02:30` (`30 2 * * *`)
-  - 실행 기간: `2026-02-27` ~ `2026-03-11` (`start_date`/`end_date` 고정)
+  - 실행 기간: `2026-02-27` ~ `2026-03-15` (`start_date`/`end_date` 고정)
 - DAG 3: `airflow/dags/mlops_train_then_infer_pipeline.py`
   - 수동 1회 트리거로 `학습 DAG` 완료 후 `추론 DAG`를 순차 실행
   - 내부 순서: `trigger_train_pipeline` -> `trigger_infer_pipeline`
@@ -137,6 +143,7 @@ uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000
 
 - `GET /health` - 헬스체크
 - `POST /analyze` - 영화 제목 기준 평점 + 추천 통합 응답
+- `POST /analyze/id` - 영화 TMDB ID 기준 평점 + 추천 통합 응답
 
 - 영화 미검색: `404` (`영화 검색 결과가 없습니다.`)
 - 모델 미로드: `503` (`모델 파일을 찾을 수 없습니다...`)

--- a/airflow/dags/mlops_infer_pipeline.py
+++ b/airflow/dags/mlops_infer_pipeline.py
@@ -44,7 +44,7 @@ with DAG(
     dag_id="mlops_infer_pipeline",
     default_args={"owner": "mlops-team3"},
     start_date=datetime(2026, 2, 27),
-    end_date=datetime(2026, 3, 11, 23, 59, 59),
+    end_date=datetime(2026, 3, 15, 23, 59, 59),
     schedule="30 2 * * *",
     catchup=False,
     tags=["mlops", "infer", "sqs", "batch"],

--- a/airflow/dags/mlops_train_pipeline.py
+++ b/airflow/dags/mlops_train_pipeline.py
@@ -44,7 +44,7 @@ with DAG(
     dag_id="mlops_train_pipeline",
     default_args={"owner": "mlops-team3"},
     start_date=datetime(2026, 2, 27),
-    end_date=datetime(2026, 3, 11, 23, 59, 59),
+    end_date=datetime(2026, 3, 15, 23, 59, 59),
     schedule="0 2 * * *",
     catchup=False,
     tags=["mlops", "train", "sqs", "wandb"],

--- a/airflow/dags/mlops_train_then_infer_pipeline.py
+++ b/airflow/dags/mlops_train_then_infer_pipeline.py
@@ -10,7 +10,7 @@ with DAG(
     dag_id="mlops_train_then_infer_pipeline",
     default_args={"owner": "mlops-team3"},
     start_date=datetime(2026, 2, 27),
-    end_date=datetime(2026, 3, 11, 23, 59, 59),
+    end_date=datetime(2026, 3, 15, 23, 59, 59),
     schedule=None,
     catchup=False,
     tags=["mlops", "orchestration", "train", "infer"],

--- a/docs/analyze-by-id-api-guide.md
+++ b/docs/analyze-by-id-api-guide.md
@@ -1,0 +1,99 @@
+# TMDB ID 기반 분석 API 가이드
+
+## 1) 한 문장 요약
+
+`/analyze/id`는 TMDB 영화 ID를 직접 입력받아, 기존 `/analyze`와 동일한 형식의 평점 예측 + 추천 결과를 반환하는 API입니다.
+
+## 2) 쉬운 설명 (Teach)
+
+기존 `/analyze`는 영화 제목으로 검색합니다.  
+하지만 제목은 띄어쓰기/동명이 영화 때문에 결과가 달라질 수 있습니다.
+
+`/analyze/id`는 숫자 ID를 쓰기 때문에 기준이 더 명확합니다.
+
+- 제목 검색 단계 없이 바로 영화 상세를 가져옵니다.
+- 같은 입력 ID면 같은 기준 영화를 분석합니다.
+- 응답 형식은 기존 `/analyze`와 같아서 프론트/클라이언트 변경이 작습니다.
+
+## 3) 핵심 구성요소 역할
+
+- `src/api/schemas.py`
+  - `AnalyzeByIdRequest` 스키마로 `movie_id`, `top_k`, `user_history`를 검증합니다.
+- `src/api/main.py`
+  - `POST /analyze/id` 엔드포인트를 처리합니다.
+  - 내부 공통 분석 함수(`_analyze_with_base_movie`)로 추천/점수 계산을 재사용합니다.
+- `src/api/tmdb_client.py`
+  - TMDB 상세/추천 조회를 수행합니다.
+  - 세션 재사용, 재시도, TTL 캐시로 API 호출 안정성을 높입니다.
+
+## 4) 헷갈리는 포인트 (Q/A)
+
+Q. `/analyze`와 `/analyze/id`의 차이는 무엇인가요?  
+A. 입력 기준만 다릅니다. `/analyze`는 제목, `/analyze/id`는 TMDB `movie_id`를 받습니다.
+
+Q. 응답 구조도 다른가요?  
+A. 아닙니다. 둘 다 `query_title`, `movie`, `recommendations`를 동일하게 반환합니다.
+
+Q. 존재하지 않는 ID를 보내면 어떻게 되나요?  
+A. `404`와 함께 `해당 movie_id를 찾을 수 없습니다.`를 반환합니다.
+
+Q. TMDB 자체 장애가 나면 어떻게 되나요?  
+A. 네트워크/외부 API 오류는 `502`로 처리됩니다.
+
+## 5) 다시 단순화한 흐름
+
+```mermaid
+graph LR
+  client[Client] --> api[POSTAnalyzeId]
+  api --> detail[TMDBMovieDetailById]
+  detail --> reco[TMDBRecommendations]
+  reco --> score[PredictAndPersonalize]
+  score --> response[AnalyzeResponse]
+```
+
+## 6) 요청/응답 예시
+
+요청:
+
+```bash
+curl -X POST http://localhost:8000/analyze/id \
+  -H "Content-Type: application/json" \
+  -d '{
+    "movie_id": 1,
+    "top_k": 3,
+    "user_history": [
+      {"title": "살인의 추억", "rating": 9.0}
+    ]
+  }'
+```
+
+응답(예시):
+
+```json
+{
+  "query_title": "1",
+  "movie": {
+    "movie_id": 1,
+    "title": "기생충",
+    "predicted_rating": 8.8
+  },
+  "recommendations": [
+    {
+      "movie_id": 2,
+      "title": "추천영화A",
+      "predicted_rating": 8.8,
+      "personalization_score": 0.41,
+      "final_score": 6.04
+    }
+  ]
+}
+```
+
+## 7) 점검 체크리스트
+
+- [ ] `POST /analyze/id`가 `movie_id` 필수값을 검증하는가
+- [ ] 존재하지 않는 ID 입력 시 `404`를 반환하는가
+- [ ] 정상 입력 시 기존 `/analyze`와 동일 응답 구조를 반환하는가
+- [ ] `top_k`가 1~10 범위에서 정상 동작하는가
+- [ ] `user_history` 포함/미포함 모두 정상 동작하는가
+

--- a/docs/cost-performance-ops-until-0315.md
+++ b/docs/cost-performance-ops-until-0315.md
@@ -1,0 +1,84 @@
+# 3/15 비용-성능 최적화 운영 가이드
+
+## 1) 한 문장 요약
+
+3/15까지 총비용 10만원을 넘기지 않으면서 `/analyze` 기능 성능과 운영 안정성을 함께 유지하는 실행 가이드입니다.
+
+## 2) 쉬운 설명 (Teach)
+
+이 문서는 “돈을 아끼되, 기능은 느려지지 않게” 운영하는 방법입니다.
+
+- 서버는 필요한 시간에만 켭니다.
+- 일이 몰릴 때만 워커를 늘립니다.
+- API는 캐시와 재시도로 응답을 안정화합니다.
+- 비용이 빨리 올라가면 그날 바로 보수 모드로 전환합니다.
+
+핵심 목표는 딱 2개입니다.
+
+1. 3/15까지 누적 비용 `<= 100,000원`
+2. `/analyze` 기능 정상 동작과 응답 안정성 유지
+
+## 3) 핵심 구성요소 역할
+
+- `airflow/dags/*`
+  - 학습/추론 파이프라인을 3/15까지 스케줄링합니다.
+- `.github/workflows/ec2-scheduled-control.yml`
+  - 시간 정책으로 EC2를 시작/중지합니다.
+- `.github/workflows/ec2-queue-autoscale.yml`
+  - 큐 backlog 기준으로 워커를 탄력 운영합니다.
+- `.github/workflows/ec2-anomaly-cost-alert.yml`
+  - 이상 징후와 비용 리스크를 감시합니다.
+- `src/api/tmdb_client.py`
+  - TMDB 호출의 세션 재사용/재시도/TTL 캐시로 API 안정성을 높입니다.
+- `src/api/main.py`
+  - `/analyze`, `/analyze/id` 응답 생성 로직을 처리합니다.
+
+## 4) 헷갈리는 포인트 (Q/A)
+
+Q. 비용 상한 10만원은 일별로 어떻게 관리하나요?  
+A. `남은 예산 / 남은 일수`로 일한도를 계산해 매일 재설정합니다.
+
+Q. 기능 최적화는 속도만 보면 되나요?  
+A. 아닙니다. 추천 응답 정상률, 동일 요청 일관성, TMDB 장애 시 복구 동작도 같이 봐야 합니다.
+
+Q. 데모 시간에는 어떻게 운영하나요?  
+A. 데모 직전 워크플로우를 수동 트리거해 warm-up하고, 종료 직후 scale-in 정책을 복원합니다.
+
+## 5) 다시 단순화한 흐름
+
+```mermaid
+graph LR
+  budgetGuard[BudgetGuard100k] --> scheduleControl[EC2ScheduledControl]
+  budgetGuard --> queueAutoscale[EC2QueueAutoscale]
+  scheduleControl --> services[ApiAndWorkers]
+  queueAutoscale --> services
+  services --> analyzeApi[AnalyzeEndpoints]
+  analyzeApi --> tmdbLayer[TMDBRetryCache]
+  services --> monitor[CostAndAnomalyMonitoring]
+```
+
+## 6) 운영 기준값
+
+- 비용 목표: `2026-03-15`까지 누적 `100,000원` 이하
+- 서비스별 시작 가드:
+  - EC2 65%
+  - S3 15%
+  - CloudWatch/로그 10%
+  - 기타/버퍼 10%
+- 초과 위험 대응 우선순위:
+  1. infer scale-out 임계값 상향
+  2. 유휴 인스턴스 scale-in 강화
+  3. 비핵심 워크플로우 수동 전환
+
+## 7) 데일리 점검 체크리스트
+
+- [ ] 오전: 워크플로우 활성/최근 schedule 성공 여부 확인
+- [ ] 오전: EC2 상태가 정책 시간대와 일치하는지 확인
+- [ ] 오후: 큐 backlog/DLQ 유입 점검
+- [ ] 오후: `/analyze` p95, 5xx, TMDB 호출량 점검
+- [ ] 마감: 누적 비용 편차 확인 후 다음날 `normal`/`cost-safe` 모드 결정
+
+## 8) 원본 계획 문서
+
+- 원본: `.cursor/plans/3월15일_안정운영_전략_1d64906e.plan.md`
+

--- a/docs/ec2-cost-optimized-operations.md
+++ b/docs/ec2-cost-optimized-operations.md
@@ -63,10 +63,10 @@ graph LR
 - scale-out: backlog가 임계치 이상이면 stopped 워커를 start
 - scale-in: backlog가 0이고 최근 N분 CPU가 임계치 이하이면 stop
 - 기본 임계치(Repository Variables)
-  - `TRAIN_QUEUE_SCALE_OUT_THRESHOLD` (기본 1)
-  - `INFER_QUEUE_SCALE_OUT_THRESHOLD` (기본 1)
-  - `QUEUE_SCALE_IN_IDLE_MINUTES` (기본 20)
-  - `QUEUE_IDLE_CPU_THRESHOLD` (기본 3)
+  - `TRAIN_QUEUE_SCALE_OUT_THRESHOLD` (기본 2)
+  - `INFER_QUEUE_SCALE_OUT_THRESHOLD` (기본 5)
+  - `QUEUE_SCALE_IN_IDLE_MINUTES` (기본 10)
+  - `QUEUE_IDLE_CPU_THRESHOLD` (기본 2)
 
 ## 8) Spot 전환 및 중단 대응 전략
 

--- a/scripts/put_supabase_ssm_params.sh
+++ b/scripts/put_supabase_ssm_params.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 사용법:
+#   AWS_PROFILE=your-profile \
+#   SUPABASE_SERVICE_ROLE_KEY="..." \
+#   bash scripts/put_supabase_ssm_params.sh
+#
+# 선택 환경변수:
+#   AWS_REGION (기본값: ap-northeast-2)
+#   SUPABASE_URL (기본값: 현재 생성된 프로젝트 URL)
+#   SUPABASE_PUBLISHABLE_KEY (기본값: 현재 생성된 publishable key)
+#   SUPABASE_PREDICTION_TABLE (기본값: prediction_logs)
+
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+SUPABASE_URL="${SUPABASE_URL:-https://wdafjmwwbxkroenvvbjz.supabase.co}"
+SUPABASE_PUBLISHABLE_KEY="${SUPABASE_PUBLISHABLE_KEY:-sb_publishable_XutZiqqZ73r_wvF64yBsFg_rctZDcWP}"
+SUPABASE_PREDICTION_TABLE="${SUPABASE_PREDICTION_TABLE:-prediction_logs}"
+
+if [[ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+  echo "오류: SUPABASE_SERVICE_ROLE_KEY 값을 먼저 설정하세요."
+  exit 1
+fi
+
+PARAM_PREFIX="/team-prj-group3/dev/mlops"
+
+echo "[1/4] SUPABASE_SERVICE_ROLE_KEY 저장"
+aws ssm put-parameter \
+  --region "$AWS_REGION" \
+  --name "${PARAM_PREFIX}/SUPABASE_SERVICE_ROLE_KEY" \
+  --type "SecureString" \
+  --value "$SUPABASE_SERVICE_ROLE_KEY" \
+  --overwrite
+
+echo "[2/4] SUPABASE_URL 저장"
+aws ssm put-parameter \
+  --region "$AWS_REGION" \
+  --name "${PARAM_PREFIX}/SUPABASE_URL" \
+  --type "String" \
+  --value "$SUPABASE_URL" \
+  --overwrite
+
+echo "[3/4] SUPABASE_PUBLISHABLE_KEY 저장"
+aws ssm put-parameter \
+  --region "$AWS_REGION" \
+  --name "${PARAM_PREFIX}/SUPABASE_PUBLISHABLE_KEY" \
+  --type "String" \
+  --value "$SUPABASE_PUBLISHABLE_KEY" \
+  --overwrite
+
+echo "[4/4] SUPABASE_PREDICTION_TABLE 저장"
+aws ssm put-parameter \
+  --region "$AWS_REGION" \
+  --name "${PARAM_PREFIX}/SUPABASE_PREDICTION_TABLE" \
+  --type "String" \
+  --value "$SUPABASE_PREDICTION_TABLE" \
+  --overwrite
+
+cat <<'EOF'
+완료:
+- /team-prj-group3/dev/mlops/SUPABASE_SERVICE_ROLE_KEY
+- /team-prj-group3/dev/mlops/SUPABASE_URL
+- /team-prj-group3/dev/mlops/SUPABASE_PUBLISHABLE_KEY
+- /team-prj-group3/dev/mlops/SUPABASE_PREDICTION_TABLE
+
+다음으로 mlops_project/.env 에 아래 파라미터 경로를 설정하세요.
+SSM_SUPABASE_SERVICE_ROLE_KEY_PARAM=/team-prj-group3/dev/mlops/SUPABASE_SERVICE_ROLE_KEY
+EOF

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 
 import requests
@@ -7,6 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
 from src.api.schemas import (
+    AnalyzeByIdRequest,
     AnalyzeByTitleResponse,
     AnalyzeRequest,
     HealthResponse,
@@ -99,10 +101,18 @@ def _resolve_movie_by_title(title: str) -> dict:
     return tmdb_client.movie_detail(int(searched["id"]))
 
 
+def _resolve_movie_by_id(movie_id: int) -> dict:
+    return tmdb_client.movie_detail(movie_id)
+
+
 def _build_user_history(items: list[UserHistoryItem]) -> list[RatedMovie]:
     history: list[RatedMovie] = []
+    resolved_by_title: dict[str, dict] = {}
     for item in items:
-        movie = _resolve_movie_by_title(item.title)
+        movie = resolved_by_title.get(item.title)
+        if movie is None:
+            movie = _resolve_movie_by_title(item.title)
+            resolved_by_title[item.title] = movie
         history.append(
             RatedMovie(
                 title=str(movie.get("title") or item.title),
@@ -130,15 +140,61 @@ def health() -> HealthResponse:
 def analyze_by_title(payload: AnalyzeRequest) -> AnalyzeByTitleResponse:
     try:
         base_movie = _resolve_movie_by_title(payload.title)
-        recommended = tmdb_client.recommendations(int(base_movie["id"]), max_items=max(10, payload.top_k * 3))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"TMDB 요청 실패: {exc}") from exc
+
+    return _analyze_with_base_movie(
+        base_movie=base_movie,
+        query_value=payload.title,
+        top_k=payload.top_k,
+        user_history_items=payload.user_history,
+    )
+
+
+@app.post(
+    "/analyze/id",
+    response_model=AnalyzeByTitleResponse,
+    summary="영화 ID로 평점 예측 + 추천 통합",
+    tags=["Movie"],
+)
+def analyze_by_id(payload: AnalyzeByIdRequest) -> AnalyzeByTitleResponse:
+    try:
+        base_movie = _resolve_movie_by_id(payload.movie_id)
+    except requests.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else 502
+        if status_code == 404:
+            raise HTTPException(status_code=404, detail="해당 movie_id를 찾을 수 없습니다.") from exc
+        raise HTTPException(status_code=502, detail=f"TMDB 요청 실패: {exc}") from exc
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"TMDB 요청 실패: {exc}") from exc
+
+    return _analyze_with_base_movie(
+        base_movie=base_movie,
+        query_value=str(payload.movie_id),
+        top_k=payload.top_k,
+        user_history_items=payload.user_history,
+    )
+
+
+def _analyze_with_base_movie(
+    *,
+    base_movie: dict,
+    query_value: str,
+    top_k: int,
+    user_history_items: list[UserHistoryItem],
+) -> AnalyzeByTitleResponse:
+    try:
+        recommended = tmdb_client.recommendations(int(base_movie["id"]), max_items=max(10, top_k * 3))
         if not recommended:
             genre_ids = [int(genre["id"]) for genre in base_movie.get("genres", []) if "id" in genre]
             recommended = tmdb_client.discover_korean_by_genres(
                 genre_ids=genre_ids,
                 exclude_movie_id=int(base_movie["id"]),
-                max_items=max(10, payload.top_k * 3),
+                max_items=max(10, top_k * 3),
             )
-        user_history = _build_user_history(payload.user_history)
+        user_history = _build_user_history(user_history_items)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except requests.RequestException as exc:
@@ -146,8 +202,15 @@ def analyze_by_title(payload: AnalyzeRequest) -> AnalyzeByTitleResponse:
 
     preference = build_preference_vector(user_history) if user_history else None
     scored_candidates: list[RecommendationItem] = []
-    for item in recommended:
-        detail = tmdb_client.movie_detail(int(item["id"]))
+    recommended_ids = [int(item["id"]) for item in recommended]
+    detail_by_id: dict[int, dict] = {}
+    with ThreadPoolExecutor(max_workers=min(6, max(1, len(recommended_ids)))) as executor:
+        details = executor.map(tmdb_client.movie_detail, recommended_ids)
+        for detail in details:
+            detail_by_id[int(detail["id"])] = detail
+
+    for movie_id in recommended_ids:
+        detail = detail_by_id[movie_id]
         candidate = CandidateMovie(
             movie_id=int(detail["id"]),
             title=str(detail.get("title") or ""),
@@ -174,9 +237,9 @@ def analyze_by_title(payload: AnalyzeRequest) -> AnalyzeByTitleResponse:
             )
         )
 
-    ranked = sorted(scored_candidates, key=lambda item: item.final_score, reverse=True)[: payload.top_k]
+    ranked = sorted(scored_candidates, key=lambda item: item.final_score, reverse=True)[:top_k]
     return AnalyzeByTitleResponse(
-        query_title=payload.title,
+        query_title=query_value,
         movie=_to_movie_score(base_movie),
         recommendations=ranked,
     )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -17,6 +17,12 @@ class AnalyzeRequest(MovieTitleRequest):
     user_history: list[UserHistoryItem] = Field(default_factory=list)
 
 
+class AnalyzeByIdRequest(BaseModel):
+    movie_id: int = Field(..., ge=1, examples=[550])
+    top_k: int = Field(default=5, ge=1, le=10)
+    user_history: list[UserHistoryItem] = Field(default_factory=list)
+
+
 class MovieScore(BaseModel):
     movie_id: int
     title: str

--- a/src/api/tmdb_client.py
+++ b/src/api/tmdb_client.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import time
+from threading import Lock
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from src.config import settings
 from src.constants import KOREAN_LANGUAGE_CODE
@@ -13,21 +17,72 @@ class TMDBClient:
         self.api_key = api_key or settings.tmdb_api_key
         self.language = language or settings.tmdb_language
         self.base_url = "https://api.themoviedb.org/3"
+        self._session = self._build_session()
+        self._cache_ttl_seconds = 1200
+        self._cache: dict[str, tuple[float, Any]] = {}
+        self._cache_lock = Lock()
+
+    def _build_session(self) -> requests.Session:
+        session = requests.Session()
+        retry = Retry(
+            total=3,
+            read=3,
+            connect=3,
+            backoff_factor=0.3,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=("GET",),
+        )
+        adapter = HTTPAdapter(max_retries=retry, pool_connections=20, pool_maxsize=20)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    def _cache_get(self, key: str) -> Any | None:
+        now = time.time()
+        with self._cache_lock:
+            item = self._cache.get(key)
+            if not item:
+                return None
+            expires_at, value = item
+            if expires_at < now:
+                self._cache.pop(key, None)
+                return None
+            return value
+
+    def _cache_set(self, key: str, value: Any, ttl_seconds: int | None = None) -> None:
+        ttl = ttl_seconds if ttl_seconds is not None else self._cache_ttl_seconds
+        with self._cache_lock:
+            self._cache[key] = (time.time() + ttl, value)
+
+    def _build_cache_key(self, path: str, params: dict[str, Any]) -> str:
+        items = sorted((str(key), str(value)) for key, value in params.items())
+        return f"{path}?{items}"
+
+    def _get_json(self, path: str, params: dict[str, Any], ttl_seconds: int | None = None) -> dict[str, Any]:
+        cache_key = self._build_cache_key(path, params)
+        cached = self._cache_get(cache_key)
+        if isinstance(cached, dict):
+            return cached
+
+        response = self._session.get(f"{self.base_url}{path}", params=params, timeout=20)
+        response.raise_for_status()
+        payload = response.json()
+        self._cache_set(cache_key, payload, ttl_seconds=ttl_seconds)
+        return payload
 
     def search_movie(self, title: str) -> dict[str, Any]:
         self._ensure_api_key()
-        response = requests.get(
-            f"{self.base_url}/search/movie",
+        data = self._get_json(
+            "/search/movie",
             params={
                 "api_key": self.api_key,
                 "language": self.language,
                 "query": title,
                 "include_adult": "false",
             },
-            timeout=20,
+            ttl_seconds=300,
         )
-        response.raise_for_status()
-        results = response.json().get("results", [])
+        results = data.get("results", [])
         if not results:
             raise ValueError("영화 검색 결과가 없습니다.")
 
@@ -36,23 +91,19 @@ class TMDBClient:
 
     def movie_detail(self, movie_id: int) -> dict[str, Any]:
         self._ensure_api_key()
-        response = requests.get(
-            f"{self.base_url}/movie/{movie_id}",
+        return self._get_json(
+            f"/movie/{movie_id}",
             params={"api_key": self.api_key, "language": self.language},
-            timeout=20,
         )
-        response.raise_for_status()
-        return response.json()
 
     def recommendations(self, movie_id: int, max_items: int = 20) -> list[dict[str, Any]]:
         self._ensure_api_key()
-        response = requests.get(
-            f"{self.base_url}/movie/{movie_id}/recommendations",
+        data = self._get_json(
+            f"/movie/{movie_id}/recommendations",
             params={"api_key": self.api_key, "language": self.language, "page": 1},
-            timeout=20,
+            ttl_seconds=1200,
         )
-        response.raise_for_status()
-        items = response.json().get("results", [])
+        items = data.get("results", [])
         korean_items = [item for item in items if item.get("original_language") == KOREAN_LANGUAGE_CODE]
         return korean_items[:max_items]
 
@@ -66,8 +117,8 @@ class TMDBClient:
         if not genre_ids:
             return []
 
-        response = requests.get(
-            f"{self.base_url}/discover/movie",
+        data = self._get_json(
+            "/discover/movie",
             params={
                 "api_key": self.api_key,
                 "language": self.language,
@@ -76,10 +127,9 @@ class TMDBClient:
                 "with_genres": ",".join(str(genre_id) for genre_id in genre_ids),
                 "page": 1,
             },
-            timeout=20,
+            ttl_seconds=1200,
         )
-        response.raise_for_status()
-        items = response.json().get("results", [])
+        items = data.get("results", [])
         filtered = [item for item in items if int(item.get("id", 0)) != exclude_movie_id]
         return filtered[:max_items]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,3 +99,51 @@ def test_analyze_model_not_loaded(monkeypatch) -> None:
 
     response = client.post("/analyze", json={"title": "기생충", "top_k": 1})
     assert response.status_code == 503
+
+
+def test_analyze_by_id(monkeypatch) -> None:
+    monkeypatch.setattr(tmdb_client, "search_movie", lambda _: {"id": 4})
+    monkeypatch.setattr(
+        tmdb_client,
+        "movie_detail",
+        lambda movie_id: _movie_detail(
+            movie_id,
+            (
+                "기생충"
+                if movie_id == 1
+                else ("추천영화A" if movie_id == 2 else ("추천영화B" if movie_id == 3 else "살인의 추억"))
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        tmdb_client, "recommendations", lambda _movie_id, max_items: [{"id": 2}, {"id": 3}]
+    )
+    monkeypatch.setattr(
+        predictor,
+        "predict_one",
+        lambda features: 8.8 if features[2] > 9 else 6.2,
+    )
+
+    response = client.post(
+        "/analyze/id",
+        json={"movie_id": 1, "top_k": 2, "user_history": [{"title": "살인의 추억", "rating": 9.3}]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["query_title"] == "1"
+    assert body["movie"]["movie_id"] == 1
+    assert len(body["recommendations"]) == 2
+
+
+def test_analyze_by_id_not_found(monkeypatch) -> None:
+    import requests
+
+    def _raise_not_found(_movie_id: int):
+        response = requests.Response()
+        response.status_code = 404
+        raise requests.HTTPError("Not Found", response=response)
+
+    monkeypatch.setattr(tmdb_client, "movie_detail", _raise_not_found)
+
+    response = client.post("/analyze/id", json={"movie_id": 999999, "top_k": 1})
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- 운영 자동화 기간 가드를 3/15까지 연장하고 Airflow/Actions/README를 동기화했습니다.
- `/analyze/id`(TMDB movie_id 기반) API를 추가하고 기존 `/analyze` 로직을 공통화했습니다.
- TMDB 호출에 세션 재사용/재시도/TTL 캐시를 적용하고 추천 상세 조회를 병렬화해 성능을 개선했습니다.
- 3/15 비용 상한(10만원) 운영을 위해 오토스케일 임계값/운영 문서를 보강했습니다.

## Test plan
- [x] `uv run pytest -q` (18 passed)
- [x] GitHub Actions 주요 워크플로우 활성/최근 schedule 성공 확인
- [x] EC2 대상 인스턴스 상태 정책 정합성 확인 및 수동 보정 실행
- [x] 운영 API 헬스체크(`GET /health`) 확인
- [x] `/analyze`, `/analyze/id` 응답 동작 확인

closes: #39 