### PR TITLE
fix: CD API Deploy 워크플로우 경로 오류 수정

### DIFF
--- a/.github/workflows/cd-api-deploy.yml
+++ b/.github/workflows/cd-api-deploy.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Prepare SSH keys for deploy script
         shell: bash
-        working-directory: mlops_project
         env:
           SSH_PRIVATE_KEY: ${{ secrets.AWS_DEPLOY_SSH_PRIVATE_KEY }}
           SSH_PUBLIC_KEY: ${{ secrets.AWS_DEPLOY_SSH_PUBLIC_KEY }}
@@ -55,7 +54,6 @@ jobs:
 
       - name: Deploy API to AWS EC2
         shell: bash
-        working-directory: mlops_project
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           INSTANCE_ID: ${{ secrets.AWS_DEPLOY_INSTANCE_ID }}
@@ -76,6 +74,5 @@ jobs:
       - name: Cleanup temporary SSH keys
         if: ${{ always() }}
         shell: bash
-        working-directory: mlops_project
         run: |
           rm -f .tmp/deploy_key .tmp/deploy_key.pub


### PR DESCRIPTION
## Summary
- `CD API Deploy to AWS` 워크플로우의 잘못된 `working-directory: mlops_project` 설정 3곳을 제거했습니다.
- GitHub Actions runner 기준 실제 체크아웃 경로와 불일치로 발생하던 `No such file or directory` 오류를 해소했습니다.
- main 병합 후 CI 성공 시 CD가 정상적으로 AWS 배포 단계까지 진행되도록 수정했습니다.

## Test plan
- [x] 워크플로우 diff로 경로 설정 제거 확인
- [ ] 이 브랜치 PR 머지 후 main 기준 `CD API Deploy to AWS` 실행 결과 확인
- [ ] 배포 단계(`Deploy API to AWS EC2`) 성공 여부 및 서비스 헬스체크 확인

Closes #59