### PR TITLE
hotfix: CD 배포 후 CloudWatch Agent 자동 보장

### DIFF
--- a/.github/workflows/cd-api-deploy.yml
+++ b/.github/workflows/cd-api-deploy.yml
@@ -186,6 +186,21 @@ jobs:
           set -euo pipefail
           bash scripts/deploy_api_aws.sh
 
+      - name: Ensure CloudWatch Agent is running
+        shell: bash
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          INSTANCE_ID: ${{ secrets.AWS_DEPLOY_INSTANCE_ID }}
+          INSTANCE_AZ: ${{ secrets.AWS_DEPLOY_INSTANCE_AZ }}
+          REMOTE_HOST: ${{ env.DEPLOY_REMOTE_HOST }}
+          REMOTE_USER: ${{ env.DEPLOY_REMOTE_USER }}
+          REMOTE_PORT: ${{ env.DEPLOY_REMOTE_PORT }}
+          SSH_KEY: .tmp/deploy_key
+          SSH_PUBLIC_KEY: .tmp/deploy_key.pub
+        run: |
+          set -euo pipefail
+          bash scripts/ensure_cloudwatch_agent.sh
+
       - name: Cleanup temporary SSH keys
         if: ${{ always() }}
         shell: bash

--- a/README.md
+++ b/README.md
@@ -122,7 +122,14 @@ graph LR
    - 현재 운영 배포는 `scripts/deploy_api_aws.sh` 기반 수동 배포를 사용합니다.
    - 배포 스크립트가 `linux/amd64` 이미지 빌드(또는 `SKIP_BUILD=true` 재사용) 후 EC2로 전송/기동하고 `/health`로 배포 검증합니다.
    - API 컨테이너는 블루/그린(`mlops-api-blue`, `mlops-api-green`) 방식으로 교체되고, Nginx 프록시(`mlops-api-proxy`)는 새 컨테이너로 업스트림을 전환합니다.
+   - `cd-api-deploy.yml`는 배포 직후 `scripts/ensure_cloudwatch_agent.sh`를 실행해 CloudWatch Agent 설치/설정/재기동을 보장합니다.
+   - 이 후처리 단계는 API 컨테이너 트래픽 전환과 분리되어 동작하므로 무중단 배포 성격을 유지합니다.
    - 배포 후 Nginx(80/443)와 Certbot TLS 인증서를 통해 `https://dongsol.com` 경로를 서비스 엔드포인트로 고정합니다.
+
+6. **CloudWatch 기반 운영 알림 Flow**
+   - `ec2-anomaly-cost-alert.yml`, `ec2-queue-autoscale.yml`가 AWS CLI로 CloudWatch 지표(`AWS/EC2`, `CWAgent`)를 조회합니다.
+   - 이상 징후 또는 스케일 이벤트 조건 충족 시 Slack Bot API(`chat.postMessage`)로 운영 채널에 알림을 전송합니다.
+   - 즉, CloudWatch Alarm이 Slack으로 직접 전송하는 방식이 아니라, GitHub Actions가 CloudWatch 지표를 판정해 Slack에 통지하는 구조입니다.
 
 ### AWS 블루/그린 무중단 배포 과정 (EC2 + Docker + Nginx)
 
@@ -186,7 +193,7 @@ cp .env.example .env
 ## 7. GitHub Actions / CI & CD
 
 - `ci.yml`: `push/pull_request/workflow_dispatch`에서 `uv sync + ruff + pytest` 실행
-- `cd-api-deploy.yml`: API 서비스의 EC2 배포 및 헬스체크 자동화
+- `cd-api-deploy.yml`: API 서비스 EC2 배포 + 헬스체크 + CloudWatch Agent 보장(`scripts/ensure_cloudwatch_agent.sh`)
 - `ci.yml`(수동 실행 시): `scripts/register_model.py`로 W&B 기반 최소 품질 게이트 확인
 - `notify.yml`: 재사용 가능한 Slack 커스텀 알림 워크플로우
 - `ec2-monitoring-daily.yml`: 매일 EC2 인스턴스 현황 집계 후 Slack 알림

--- a/scripts/ensure_cloudwatch_agent.sh
+++ b/scripts/ensure_cloudwatch_agent.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# 배포 대상 EC2에 CloudWatch Agent를 설치/기동하여 CWAgent 지표를 보장한다.
+
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+INSTANCE_ID="${INSTANCE_ID:?INSTANCE_ID를 설정하세요}"
+INSTANCE_AZ="${INSTANCE_AZ:?INSTANCE_AZ를 설정하세요}"
+REMOTE_HOST="${REMOTE_HOST:?REMOTE_HOST를 설정하세요}"
+REMOTE_USER="${REMOTE_USER:?REMOTE_USER를 설정하세요}"
+REMOTE_PORT="${REMOTE_PORT:-22}"
+SSH_KEY="${SSH_KEY:?SSH_KEY를 설정하세요}"
+SSH_PUBLIC_KEY="${SSH_PUBLIC_KEY:-${SSH_KEY}.pub}"
+
+if [[ ! -f "${SSH_KEY}" ]]; then
+  echo "ERROR: SSH 키 파일이 없습니다: ${SSH_KEY}"
+  exit 1
+fi
+
+if [[ ! -f "${SSH_PUBLIC_KEY}" ]]; then
+  echo "ERROR: SSH 공개키 파일이 없습니다: ${SSH_PUBLIC_KEY}"
+  exit 1
+fi
+
+echo "=== CloudWatch Agent 보장 시작 ==="
+echo "instance_id: ${INSTANCE_ID}"
+echo "remote: ${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_PORT}"
+
+aws ec2-instance-connect send-ssh-public-key \
+  --region "${AWS_REGION}" \
+  --instance-id "${INSTANCE_ID}" \
+  --availability-zone "${INSTANCE_AZ}" \
+  --instance-os-user "${REMOTE_USER}" \
+  --ssh-public-key "file://${SSH_PUBLIC_KEY}" >/dev/null
+
+ssh -i "${SSH_KEY}" -p "${REMOTE_PORT}" -o StrictHostKeyChecking=accept-new \
+  "${REMOTE_USER}@${REMOTE_HOST}" "bash -s" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+if command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y amazon-cloudwatch-agent >/dev/null
+elif command -v yum >/dev/null 2>&1; then
+  sudo yum install -y amazon-cloudwatch-agent >/dev/null
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -y >/dev/null
+  sudo apt-get install -y amazon-cloudwatch-agent >/dev/null
+else
+  echo "ERROR: 지원하지 않는 패키지 매니저입니다."
+  exit 1
+fi
+
+sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json >/dev/null <<'EOF'
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "namespace": "CWAgent",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "aggregation_dimensions": [["InstanceId"]],
+    "metrics_collected": {
+      "disk": {
+        "measurement": ["used_percent"],
+        "resources": ["/"],
+        "ignore_file_system_types": ["sysfs", "devtmpfs", "tmpfs", "overlay", "squashfs"]
+      }
+    }
+  }
+}
+EOF
+
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+  -s >/dev/null
+
+sudo systemctl enable amazon-cloudwatch-agent >/dev/null
+sudo systemctl restart amazon-cloudwatch-agent
+sudo systemctl is-active --quiet amazon-cloudwatch-agent
+REMOTE_SCRIPT
+
+echo "CloudWatch Agent 실행 확인 완료"


### PR DESCRIPTION
## Summary
- CD 배포 워크플로우에 CloudWatch Agent 보장 단계를 추가해 배포 직후 에이전트 설치/기동을 자동화했습니다.
- `scripts/ensure_cloudwatch_agent.sh`를 추가해 CWAgent 디스크 지표(`disk_used_percent`) 수집 설정을 표준화했습니다.
- 서비스 트래픽 처리와 분리된 후처리 단계로 구성해 무중단 성격을 유지했습니다.

## Test plan
- [x] `bash -n scripts/ensure_cloudwatch_agent.sh`
- [ ] GitHub Actions `CD API Deploy to AWS` 수동 실행 (`workflow_dispatch`)
- [ ] 실행 후 `ec2-anomaly-cost-alert`에서 CWAgent 지표 수집 여부 확인

## Related issue
- Closes #72