### PR TITLE
워크플로우 종료 기준일을 오늘로 변경

### DIFF
--- a/.github/workflows/ec2-anomaly-cost-alert.yml
+++ b/.github/workflows/ec2-anomaly-cost-alert.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_START_DATE: "2026-02-27"
-      PROJECT_STOP_DATE: "2026-03-15"
+      PROJECT_STOP_DATE: "2026-03-13"
     steps:
       - name: Check orchestration period window
         id: period_guard
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_START_DATE: "2026-02-27"
-      PROJECT_STOP_DATE: "2026-03-15"
+      PROJECT_STOP_DATE: "2026-03-13"
     steps:
       - name: Check orchestration period window
         id: period_guard

--- a/.github/workflows/ec2-queue-autoscale.yml
+++ b/.github/workflows/ec2-queue-autoscale.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_START_DATE: "2026-02-27"
-      PROJECT_STOP_DATE: "2026-03-15"
+      PROJECT_STOP_DATE: "2026-03-13"
     steps:
       - name: Check orchestration period window
         id: period_guard

--- a/.github/workflows/ec2-scheduled-control.yml
+++ b/.github/workflows/ec2-scheduled-control.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_START_DATE: "2026-02-27"
-      PROJECT_STOP_DATE: "2026-03-15"
+      PROJECT_STOP_DATE: "2026-03-13"
       PROJECT_ASG_NAME: "mlops-api-asg"
       PROJECT_DB_IDENTIFIER_PREFIX: "team-prj-group3-dev-mlops-db"
     steps:


### PR DESCRIPTION
## 변경 내용
- EC2 관련 워크플로우의 `PROJECT_STOP_DATE`를 `2026-03-13`(오늘)로 변경
- 종료일 도달 시 강제 정지 로직이 즉시 적용되도록 조정

## 포함 파일
- `.github/workflows/ec2-scheduled-control.yml`
- `.github/workflows/ec2-queue-autoscale.yml`
- `.github/workflows/ec2-anomaly-cost-alert.yml`

## 확인 방법
- `EC2 Scheduled Start Stop`를 수동 실행하면 `Force shutdown after project end date`가 실행됨